### PR TITLE
Python 3.9 support

### DIFF
--- a/googletrans/models.py
+++ b/googletrans/models.py
@@ -39,7 +39,7 @@ class Translated(Base):
         origin,
         text,
         pronunciation,
-        parts: List[TranslatedPart] | None,
+        parts: List[TranslatedPart] or None,
         extra_data=None,
         **kwargs
     ):


### PR DESCRIPTION
Just change this thing and your library will be supported by python 3.9+ instead of 3.10+